### PR TITLE
Refactor to introduce Repositories (Snaps & Accounts) and Handlers for REST API services (Store, Dashboard)

### DIFF
--- a/bin/dashboard/main.go
+++ b/bin/dashboard/main.go
@@ -2,8 +2,14 @@ package main
 
 import (
 	"github.com/freetocompute/kebe/config"
+	"github.com/freetocompute/kebe/config/configkey"
 	"github.com/freetocompute/kebe/pkg/dashboard/server"
+	"github.com/freetocompute/kebe/pkg/database"
+	"github.com/freetocompute/kebe/pkg/middleware"
+	"github.com/freetocompute/kebe/pkg/repositories"
+	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func init() {
@@ -11,7 +17,28 @@ func init() {
 }
 
 func main() {
-	s := &server.Server{}
-	s.Init()
+	logrus.SetLevel(logrus.TraceLevel)
+	config.LoadConfig()
+
+	logLevelConfig := viper.GetString(configkey.LogLevel)
+	l, errLevel := logrus.ParseLevel(logLevelConfig)
+	if errLevel != nil {
+		logrus.Error(errLevel)
+	} else {
+		logrus.SetLevel(l)
+	}
+
+	dashboardPort := viper.GetInt(configkey.DashboardPort)
+	useRequestLogger := viper.GetBool(configkey.RequestLogger)
+	db, _ := database.CreateDatabase()
+	handler := server.NewDashboardHandler(repositories.NewAccountRepository(db), repositories.NewSnapsRepository(db))
+
+	s := server.New(useRequestLogger, handler, dashboardPort)
+
+	rootKey := config.MustGetString(configkey.MacaroonRootKey)
+
+	checkForAuthorizedUserFunc := middleware.CheckForAuthorizedUserWithMacaroons(db, rootKey)
+	s.SetupEndpoints(checkForAuthorizedUserFunc)
+
 	s.Run()
 }

--- a/build-aux/docker/Dockerfile.dashboard
+++ b/build-aux/docker/Dockerfile.dashboard
@@ -1,4 +1,5 @@
-FROM golang:1.16 AS builder
+#FROM golang:1.16 AS builder
+FROM kebe-store-base AS builder
 
 COPY . /source
 WORKDIR /source

--- a/build-aux/docker/Dockerfile.store
+++ b/build-aux/docker/Dockerfile.store
@@ -1,4 +1,6 @@
-FROM golang:1.16 AS builder
+# FROM golang:1.16 AS builder
+
+FROM kebe-store-base AS builder
 
 COPY . /source
 WORKDIR /source

--- a/build-aux/docker/Dockerfile.store
+++ b/build-aux/docker/Dockerfile.store
@@ -1,5 +1,3 @@
-# FROM golang:1.16 AS builder
-
 FROM kebe-store-base AS builder
 
 COPY . /source

--- a/build-aux/docker/Dockerfile.store.base
+++ b/build-aux/docker/Dockerfile.store.base
@@ -1,0 +1,5 @@
+FROM golang:1.16 AS builder
+
+COPY . /tmp/source
+WORKDIR /tmp/source
+RUN go build -o /bin/kebe-store bin/store/main.go

--- a/pkg/admind/server.go
+++ b/pkg/admind/server.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/freetocompute/kebe/pkg/repositories"
+
 	"github.com/freetocompute/kebe/config"
 	"github.com/freetocompute/kebe/config/configkey"
 	"github.com/freetocompute/kebe/pkg/admind/requests"
-	"github.com/freetocompute/kebe/pkg/dashboard/server"
 	"github.com/freetocompute/kebe/pkg/database"
 	"github.com/freetocompute/kebe/pkg/middleware"
 	"github.com/freetocompute/kebe/pkg/models"
@@ -21,6 +22,7 @@ import (
 type Server struct {
 	db     *gorm.DB
 	engine *gin.Engine
+	snaps  *repositories.SnapsRepository
 }
 
 func (s *Server) Init() {
@@ -50,6 +52,7 @@ func (s *Server) Init() {
 
 	db, _ := database.CreateDatabase()
 	s.db = db
+	s.snaps = repositories.NewSnapsRepository(db)
 
 	s.SetupEndpoints(r)
 }
@@ -99,7 +102,7 @@ func (s *Server) addTrack(c *gin.Context) {
 
 			s.db.Save(&track)
 
-			server.AddRisks(s.db, snapEntry.ID, track.ID)
+			s.snaps.AddDefaultRisks(snapEntry.ID, track.ID)
 
 			c.Status(http.StatusCreated)
 			return

--- a/pkg/dashboard/server/endpoints.go
+++ b/pkg/dashboard/server/endpoints.go
@@ -27,8 +27,6 @@ func (s *Server) SetupEndpoints() {
 	private.POST("/snap-push", s.pushSnap)
 	private.POST("/snap-release", s.snapRelease)
 
-	//------------ BELOW THIS LINE NOT REDONE
-
 	apiV2Private := r.Group("/api/v2")
 	apiV2Private.Use(middleware.CheckForAuthorizedUserWithMacaroons(s.db, rootKey))
 	apiV2Private.GET("/snaps/:snap/channel-map", s.getSnapChannelMap)

--- a/pkg/dashboard/server/endpoints.go
+++ b/pkg/dashboard/server/endpoints.go
@@ -1,14 +1,11 @@
 package server
 
 import (
-	"github.com/freetocompute/kebe/config"
-	"github.com/freetocompute/kebe/config/configkey"
-	"github.com/freetocompute/kebe/pkg/middleware"
+	"github.com/gin-gonic/gin"
 )
 
-func (s *Server) SetupEndpoints() {
+func (s *Server) SetupEndpoints(checkForAuthorizedUser gin.HandlerFunc) {
 	r := s.engine
-	rootKey := config.MustGetString(configkey.MacaroonRootKey)
 
 	public := r.Group("/dev/api")
 	public.POST("/acl/", s.postACL)
@@ -18,7 +15,7 @@ func (s *Server) SetupEndpoints() {
 	public.POST("/acl/verify/", s.verifyACL)
 
 	private := r.Group("/dev/api")
-	private.Use(middleware.CheckForAuthorizedUserWithMacaroons(s.db, rootKey))
+	private.Use(checkForAuthorizedUser)
 
 	private.GET("/account", s.getAccount)
 	private.POST("/register-name", s.registerSnapName)
@@ -28,7 +25,7 @@ func (s *Server) SetupEndpoints() {
 	private.POST("/snap-release", s.snapRelease)
 
 	apiV2Private := r.Group("/api/v2")
-	apiV2Private.Use(middleware.CheckForAuthorizedUserWithMacaroons(s.db, rootKey))
+	apiV2Private.Use(checkForAuthorizedUser)
 	apiV2Private.GET("/snaps/:snap/channel-map", s.getSnapChannelMap)
 
 	// TODO: implement /api/v2/snaps/<snap-name>/releases for `snapcraft list-revisions <snap-name>`

--- a/pkg/dashboard/server/endpoints.go
+++ b/pkg/dashboard/server/endpoints.go
@@ -4,10 +4,10 @@ import (
 	"github.com/freetocompute/kebe/config"
 	"github.com/freetocompute/kebe/config/configkey"
 	"github.com/freetocompute/kebe/pkg/middleware"
-	"github.com/gin-gonic/gin"
 )
 
-func (s *Server) SetupEndpoints(r *gin.Engine) {
+func (s *Server) SetupEndpoints() {
+	r := s.engine
 	rootKey := config.MustGetString(configkey.MacaroonRootKey)
 
 	public := r.Group("/dev/api")
@@ -15,18 +15,19 @@ func (s *Server) SetupEndpoints(r *gin.Engine) {
 
 	// TODO: document this somehow
 	public.GET("/snap-status/:id", s.getStatus)
+	public.POST("/acl/verify/", s.verifyACL)
 
 	private := r.Group("/dev/api")
 	private.Use(middleware.CheckForAuthorizedUserWithMacaroons(s.db, rootKey))
 
-	public.POST("/acl/verify/", s.verifyACL)
-
 	private.GET("/account", s.getAccount)
 	private.POST("/register-name", s.registerSnapName)
+
 	private.POST("/account/account-key", s.addAccountKey)
 	private.POST("/snap-push", s.pushSnap)
-
 	private.POST("/snap-release", s.snapRelease)
+
+	//------------ BELOW THIS LINE NOT REDONE
 
 	apiV2Private := r.Group("/api/v2")
 	apiV2Private.Use(middleware.CheckForAuthorizedUserWithMacaroons(s.db, rootKey))

--- a/pkg/dashboard/server/handler.go
+++ b/pkg/dashboard/server/handler.go
@@ -335,6 +335,7 @@ func (d *DashboardHandler) RegisterSnapName(accountEmail string, isDryRun bool, 
 		account, err2 := d.accounts.GetAccountByEmail(accountEmail, false)
 		if err2 == nil && account != nil {
 			if !isDryRun {
+				logrus.Trace("This is not a dry run")
 				snap, err3 := d.snaps.AddSnap(snapName, account.ID)
 				if err3 == nil && snap != nil {
 					resp := responses.RegisterSnap{
@@ -345,8 +346,9 @@ func (d *DashboardHandler) RegisterSnapName(accountEmail string, isDryRun bool, 
 					return &resp, nil
 				}
 			} else {
+				logrus.Trace("This is a dry run")
 				snap, err3 := d.snaps.GetSnap(snapName, false)
-				if err3 == nil && snap != nil {
+				if err3 == nil && snap == nil {
 					resp := responses.RegisterSnap{
 						Name: snapName,
 					}

--- a/pkg/dashboard/server/handler.go
+++ b/pkg/dashboard/server/handler.go
@@ -57,7 +57,7 @@ func NewDashboardHandler(accts repositories.IAccountRepository, snaps repositori
 }
 
 func (d *DashboardHandler) GetSnapChannelMap(snapName string) (*generatedResponses.Root, error) {
-	snap, err := d.snaps.GetSnap(snapName)
+	snap, err := d.snaps.GetSnap(snapName, false)
 	if err == nil && snap != nil {
 		var root generatedResponses.Root
 		var channelMapItems []*generatedResponses.ChannelMapItems
@@ -135,7 +135,7 @@ func (d *DashboardHandler) GetSnapChannelMap(snapName string) (*generatedRespons
 
 func (d *DashboardHandler) ReleaseSnap(name string, revision uint, channels []string) (bool, error) {
 	if name != "" && revision != 0 && len(channels) > 0 {
-		snapEntry, err := d.snaps.GetSnap(name)
+		snapEntry, err := d.snaps.GetSnap(name, false)
 		if err == nil && snapEntry != nil {
 			var trackForRelease string
 			var riskForRelease string
@@ -345,7 +345,7 @@ func (d *DashboardHandler) RegisterSnapName(accountEmail string, isDryRun bool, 
 					return &resp, nil
 				}
 			} else {
-				snap, err3 := d.snaps.GetSnap(snapName)
+				snap, err3 := d.snaps.GetSnap(snapName, false)
 				if err3 == nil && snap != nil {
 					resp := responses.RegisterSnap{
 						Name: snapName,

--- a/pkg/dashboard/server/handler.go
+++ b/pkg/dashboard/server/handler.go
@@ -1,0 +1,439 @@
+package server
+
+import (
+	bytes2 "bytes"
+	"context"
+	"crypto"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	generatedResponses "github.com/freetocompute/kebe/generated/responses"
+
+	store "github.com/freetocompute/kebe/pkg/store/responses"
+
+	"github.com/freetocompute/kebe/pkg/models"
+	"github.com/freetocompute/kebe/pkg/objectstore"
+	"github.com/freetocompute/kebe/pkg/sha"
+	"github.com/minio/minio-go/v7"
+
+	"github.com/freetocompute/kebe/config"
+	"github.com/freetocompute/kebe/config/configkey"
+	"github.com/freetocompute/kebe/pkg/auth"
+	"github.com/spf13/viper"
+
+	"gopkg.in/macaroon.v2"
+	macaroonv2 "gopkg.in/macaroon.v2"
+
+	"github.com/freetocompute/kebe/pkg/repositories"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/freetocompute/kebe/pkg/dashboard/requests"
+	"github.com/freetocompute/kebe/pkg/dashboard/responses"
+	"github.com/freetocompute/kebe/pkg/middleware"
+)
+
+type IDashboardHandler interface {
+	VerifyACL(verify *requests.Verify) (*responses.Verify, error)
+	GetAccount(accountEmail string) (*responses.AccountInfo, error)
+	RegisterSnapName(accountEmail string, dryRun bool, snapName string) (*responses.RegisterSnap, error)
+	AddAccountKey(accountEmail string, keyName string, publicKeyId string, pubKeyEncoded string) (*models.Key, error)
+	GetACLMacaroon(acl string) (*macaroonv2.Macaroon, error)
+	GetUploadStatus(upDownId string) (*responses.Status, error)
+	PushSnap(snapName string, upDownId string, fileSize uint, channels []string) (*store.Upload, error)
+	ReleaseSnap(name string, revision uint, channels []string) (bool, error)
+	GetSnapChannelMap(snapName string) (*generatedResponses.Root, error)
+}
+
+type DashboardHandler struct {
+	accounts repositories.IAccountRepository
+	snaps    repositories.ISnapsRepository
+}
+
+func NewDashboardHandler(accts repositories.IAccountRepository, snaps repositories.ISnapsRepository) *DashboardHandler {
+	return &DashboardHandler{accounts: accts, snaps: snaps}
+}
+
+func (d *DashboardHandler) GetSnapChannelMap(snapName string) (*generatedResponses.Root, error) {
+	snap, err := d.snaps.GetSnap(snapName)
+	if err == nil && snap != nil {
+		var root generatedResponses.Root
+		var channelMapItems []*generatedResponses.ChannelMapItems
+		var revisions []*generatedResponses.RevisionsItems
+		var channelItems []*generatedResponses.ChannelsItems
+		var snapTracks []*generatedResponses.TracksItems
+
+		logrus.Tracef("Getting tracks for: %s", snap.Name)
+
+		tracks, err2 := d.snaps.GetTracks(snap.ID)
+		if err2 == nil && tracks != nil {
+			for _, track := range *tracks {
+				snapTracks = append(snapTracks, &generatedResponses.TracksItems{
+					Name: track.Name,
+				})
+
+				logrus.Tracef("Getting risks for track: %s", track.Name)
+
+				risks, err3 := d.snaps.GetRisks(track.ID)
+				if err3 == nil && risks != nil {
+					for _, risk := range *risks {
+						logrus.Tracef("Getting revision for risk: %s", risk.Name)
+						revision, err4 := d.snaps.GetRevision(risk.RevisionID)
+						if err4 == nil && revision != nil {
+							logrus.Tracef("Got revision %d", revision.ID)
+							channelMapItems = append(channelMapItems, &generatedResponses.ChannelMapItems{
+								Architecture: "amd64",
+								Channel:      track.Name + "/" + risk.Name,
+								Revision:     int(revision.ID),
+								Progressive:  &generatedResponses.Progressive{},
+							})
+							//
+							revisions = append(revisions, &generatedResponses.RevisionsItems{
+								Architectures: []string{"amd64"},
+								Revision:      int(revision.ID),
+								Version:       "1",
+								Attributes:    &generatedResponses.Attributes{},
+								Confinement:   "strict",
+								Epoch:         &generatedResponses.Epoch{},
+								Grade:         "stable",
+								Sha3384:       revision.SHA3_384,
+								Size:          int(revision.Size),
+							})
+							//
+							channelItems = append(channelItems, &generatedResponses.ChannelsItems{
+								Name:  track.Name + "/" + risk.Name,
+								Risk:  risk.Name,
+								Track: track.Name,
+							})
+						}
+					}
+				}
+			}
+
+			root.ChannelMap = channelMapItems
+			root.Revisions = revisions
+
+			root.Snap = &generatedResponses.Snap{
+				Channels: channelItems,
+				Name:     snap.Name,
+				Tracks:   snapTracks,
+			}
+			return &root, nil
+		}
+	} else if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+
+	unknownErr := errors.New("unknown error encountered")
+	logrus.Error(unknownErr)
+
+	panic("unknown error encountered")
+}
+
+func (d *DashboardHandler) ReleaseSnap(name string, revision uint, channels []string) (bool, error) {
+	if name != "" && revision != 0 && len(channels) > 0 {
+		snapEntry, err := d.snaps.GetSnap(name)
+		if err == nil && snapEntry != nil {
+			var trackForRelease string
+			var riskForRelease string
+			for _, cn := range channels {
+				// It's possible this comes in the form:
+				//   - single string values "edge" where the track is assumed to be "latest" there is no branch
+				//   - two values "latest/edge" where the risk is proceeded by the track
+				//   - three values "latest/edge/some_branch"
+				parts := strings.Split(cn, "/")
+				if len(parts) == 1 {
+					riskForRelease = parts[0]
+					trackForRelease = "latest"
+				} else if len(parts) == 2 {
+					trackForRelease = parts[0]
+					riskForRelease = parts[1]
+				} else if len(parts) == 3 {
+					logrus.Error(errors.New("branches not supported yet"))
+					return false, errors.New("branches not supported yet")
+				}
+
+				track, err2 := d.snaps.SetChannelRevision(trackForRelease, riskForRelease, revision, snapEntry.ID)
+				if err2 != nil {
+					logrus.Error(err2)
+					return false, err2
+				}
+
+				if track == nil {
+					logrus.Errorf("could not set revision for track/risk: %s/%s", trackForRelease, riskForRelease)
+					return false, errors.New("could not set revision for track")
+				}
+			}
+
+			return true, nil
+
+		} else if err != nil {
+			logrus.Error(err)
+			return false, err
+		}
+	} else {
+		emptyErr := errors.New("all fields must be non-empty")
+		logrus.Error(emptyErr)
+		return false, emptyErr
+	}
+
+	unknownError := errors.New("unknown error encountered")
+	logrus.Error(unknownError)
+	return false, unknownError
+}
+
+func (d *DashboardHandler) PushSnap(snapName string, upDownId string, fileSize uint, channels []string) (*store.Upload, error) {
+	snapUpload, err := d.snaps.AddUpload(snapName, upDownId, fileSize, channels)
+	if err == nil && snapUpload != nil {
+		//// File saved successfully. Return proper result
+		//// TODO: this URL needs to be serviced by a worker thread
+		snapUploadResp := store.Upload{
+			Success: true,
+			// TODO: check this at start-up, verify Must then
+			StatusDetailsURL: config.MustGetString(configkey.DashboardURL) + "/dev/api/snap-status/" + upDownId,
+		}
+
+		return &snapUploadResp, nil
+	}
+
+	return nil, errors.New("unknown error encountered")
+}
+
+func (d *DashboardHandler) GetUploadStatus(upDownId string) (*responses.Status, error) {
+	// We need to move the snap from the unscanned bucket to the snaps bucket
+	snapUpload, err := d.snaps.GetUpload(upDownId)
+	if err == nil && snapUpload != nil {
+		snapFileName := upDownId + ".snap"
+
+		// get the sha3_384 of the file so we can figure out if it already exists as a revision
+		obj, err2 := objectstore.GetMinioClient().GetObject(context.Background(), "unscanned", snapFileName, minio.GetObjectOptions{})
+		if err2 != nil {
+			panic(err2)
+		}
+
+		bytes, err3 := io.ReadAll(obj)
+		h := crypto.SHA3_384.New()
+		if err3 != nil {
+			panic(err3)
+		}
+		h.Write(bytes)
+		actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
+
+		rev, err4 := d.snaps.GetRevisionBySHA(actualSha3)
+		var revision models.SnapRevision
+		if err4 == nil && rev != nil {
+			revision = *rev
+			logrus.Infof("Revision %s found to exist for snap %s, updating channels with existing revision", actualSha3, snapUpload.Name)
+			// This revision already exists on some channel, we just
+			// need to update the requested channels to have this revision
+
+			// need to discard upload. remove record
+			// TODO: add to auditing later?
+			logrus.Infof("Removing object %s from buckect %s", snapFileName, "unscanned")
+			err4 = objectstore.GetMinioClient().RemoveObject(context.Background(), "unscanned", snapFileName, minio.RemoveObjectOptions{})
+			if err4 != nil {
+				logrus.Error(err4)
+			}
+		} else if err4 == nil && rev == nil {
+			logrus.Infof("Revision %s not found to exist for snap %s, creating revision and updating channels with revision", actualSha3, snapUpload.Name)
+			objStore := objectstore.NewObjectStore()
+			err4 = objStore.Move("unscanned", "snaps", snapFileName)
+			if err4 != nil {
+				logrus.Error(err4)
+				return nil, err4
+			}
+
+			digest, _, err5 := sha.SnapFileSHA3_384FromReader(bytes2.NewReader(bytes))
+			if err5 != nil {
+				panic(err5)
+			}
+
+			revision = models.SnapRevision{
+				SnapFilename:   snapFileName,
+				SnapEntryID:    snapUpload.SnapEntryID,
+				SHA3_384:       actualSha3,
+				SHA3384Encoded: digest,
+				Size:           int64(snapUpload.Filesize),
+			}
+
+			_, err2 = d.snaps.UpdateRevision(&revision, &bytes)
+			if err2 != nil {
+				logrus.Error(err2)
+				return nil, err2
+			}
+		} else {
+			logrus.Error(err4)
+			return nil, err4
+		}
+
+		// TODO: fix lazy
+		channels := strings.Split(snapUpload.Channels, ",")
+		err2 = d.snaps.ReleaseSnap(channels, snapUpload.SnapEntryID, revision.ID)
+		if err2 == nil {
+			resp := &responses.Status{
+				Processed: true,
+				Code:      "ready_to_release",
+				Revision:  int(revision.ID),
+			}
+
+			return resp, nil
+		}
+
+		logrus.Error(err2)
+		return nil, err2
+	}
+
+	logrus.Error(err)
+	return nil, err
+}
+
+func (d *DashboardHandler) GetACLMacaroon(acl string) (*macaroonv2.Macaroon, error) {
+	// TODO: check these sooner, cache the values and ensure they exist on start-up
+	rootKeyString := config.MustGetString(configkey.MacaroonRootKey)
+	rootMacaroonId := config.MustGetString(configkey.MacaroonRootId)
+	rootMacaroonLocation := config.MustGetString(configkey.MacaroonRootLocation)
+	m := auth.MustNewMacaroon([]byte(rootKeyString), []byte(rootMacaroonId), rootMacaroonLocation, macaroon.V1)
+
+	dischargeKeyString := viper.GetString(configkey.MacaroonDischargeKey)
+	if len(dischargeKeyString) == 0 {
+		// this is panic worthy
+		// TODO: check these sooner
+		panic(errors.New("discharge key must be set"))
+	}
+	thirdPartyCaveatId := config.MustGetString(configkey.MacaroonThirdPartyCaveatId)
+	thirdPartLocation := config.MustGetString(configkey.MacaroonThirdPartyLocation)
+	err := m.AddThirdPartyCaveat([]byte(dischargeKeyString), []byte(thirdPartyCaveatId), thirdPartLocation)
+	if err != nil {
+		panic(err)
+	}
+
+	_ = m.AddFirstPartyCaveat([]byte(acl))
+
+	return m, nil
+}
+
+func (d *DashboardHandler) AddAccountKey(accountEmail string, keyName string, publicKeyId string, pubKeyEncoded string) (*models.Key, error) {
+	if accountEmail != "" && keyName != "" && publicKeyId != "" && pubKeyEncoded != "" {
+		acct, err2 := d.accounts.AddKey(keyName, publicKeyId, pubKeyEncoded, accountEmail)
+		if err2 == nil && acct != nil {
+			return acct, nil
+		} else if err2 != nil {
+			logrus.Error(err2)
+			return nil, err2
+		}
+	}
+
+	logrus.Errorf("accountEmail=%s, keyName=%s, publicKeyId=%s and pubKeyEncoded=%s must all be non-empty", accountEmail, keyName, publicKeyId, pubKeyEncoded)
+	return nil, errors.New("email, key name, public key id and public key encoded must all be non-empty")
+}
+
+func (d *DashboardHandler) RegisterSnapName(accountEmail string, isDryRun bool, snapName string) (*responses.RegisterSnap, error) {
+	if accountEmail != "" {
+		account, err2 := d.accounts.GetAccountByEmail(accountEmail, false)
+		if err2 == nil && account != nil {
+			if !isDryRun {
+				snap, err3 := d.snaps.AddSnap(snapName, account.ID)
+				if err3 == nil && snap != nil {
+					resp := responses.RegisterSnap{
+						Id:   snap.SnapStoreID,
+						Name: snap.Name,
+					}
+
+					return &resp, nil
+				}
+			} else {
+				snap, err3 := d.snaps.GetSnap(snapName)
+				if err3 == nil && snap != nil {
+					resp := responses.RegisterSnap{
+						Name: snapName,
+					}
+					return &resp, nil
+				}
+			}
+		}
+	}
+
+	return nil, errors.New("account not found")
+}
+
+func (d *DashboardHandler) GetAccount(accountEmail string) (*responses.AccountInfo, error) {
+	if accountEmail != "" {
+		account, err := d.accounts.GetAccountByEmail(accountEmail, true)
+
+		if err == nil {
+			accountInfoResponse := responses.AccountInfo{
+				AccountId:   account.AccountId,
+				Snaps:       map[string]map[string]responses.Snap{},
+				AccountKeys: []responses.Key{},
+			}
+
+			for _, k := range account.Keys {
+				accountInfoResponse.AccountKeys = append(accountInfoResponse.AccountKeys, responses.Key{
+					PublicKeySHA384: k.SHA3384,
+					Name:            k.Name,
+				})
+			}
+
+			snaps := map[string]responses.Snap{}
+			for _, s := range account.SnapEntries {
+				// TODO: replace with real data
+				snaps[s.Name] = responses.Snap{
+					Status:  "Approved",
+					SnapId:  s.SnapStoreID,
+					Store:   "Global",
+					Since:   "2016-07-04T23:37:52Z",
+					Private: false,
+				}
+			}
+
+			accountInfoResponse.Snaps["16"] = snaps
+
+			// TODO: this would actually need to be filled in
+			return &accountInfoResponse, nil
+		}
+
+		logrus.Error(err)
+	}
+
+	return nil, errors.New("not found")
+}
+
+func (d *DashboardHandler) VerifyACL(verify *requests.Verify) (*responses.Verify, error) {
+	userEmail, err := middleware.VerifyAndGetEmail(verify.AuthData.Authorization)
+	if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+
+	user, err := d.accounts.GetAccountByEmail(*userEmail, false)
+	if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+
+	if user != nil {
+		v := responses.Verify{
+			Allowed:               true,
+			DeviceRefreshRequired: false,
+			RefreshRequired:       false,
+			Account: &responses.VerifyAccount{
+				Email:       user.Email,
+				DisplayName: user.DisplayName,
+				OpenId:      "oid1234",
+				Verified:    true,
+			},
+			Device:      nil,
+			LastAuth:    "2016-05-26T12:53:23Z",
+			Permissions: &[]string{"package_access", "package_manage", "package_push", "package_register", "package_release", "package_update"},
+			SnapIds:     nil,
+			Channels:    nil,
+		}
+
+		return &v, nil
+	}
+
+	return nil, errors.New("user not found")
+}

--- a/pkg/dashboard/server/handler.go
+++ b/pkg/dashboard/server/handler.go
@@ -222,7 +222,7 @@ func (d *DashboardHandler) GetUploadStatus(upDownId string) (*responses.Status, 
 		h.Write(bytes)
 		actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
 
-		rev, err4 := d.snaps.GetRevisionBySHA(actualSha3)
+		rev, err4 := d.snaps.GetRevisionBySHA(actualSha3, false)
 		var revision models.SnapRevision
 		if err4 == nil && rev != nil {
 			revision = *rev

--- a/pkg/dashboard/server/server.go
+++ b/pkg/dashboard/server/server.go
@@ -223,6 +223,7 @@ func (s *Server) registerSnapName(c *gin.Context) {
 		resp, err2 := s.handler.RegisterSnapName(accountEmail, isDryRun, registerSnapName.Name)
 		if err2 == nil && resp != nil {
 			c.JSON(http.StatusOK, resp)
+			return
 		}
 	} else {
 		logrus.Error(err)

--- a/pkg/dashboard/server/server.go
+++ b/pkg/dashboard/server/server.go
@@ -1,49 +1,39 @@
 package server
 
 import (
-	bytes2 "bytes"
-	"context"
-	"crypto"
 	"encoding/base64"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"strconv"
-	"strings"
+
+	"github.com/freetocompute/kebe/pkg/assertions"
+	"github.com/snapcore/snapd/asserts"
+
+	"github.com/freetocompute/kebe/pkg/dashboard/requests"
+
+	"github.com/freetocompute/kebe/pkg/auth"
+	"github.com/freetocompute/kebe/pkg/dashboard/responses"
+
+	"github.com/freetocompute/kebe/pkg/repositories"
 
 	"github.com/freetocompute/kebe/config"
 	"github.com/freetocompute/kebe/config/configkey"
-	generatedResponses "github.com/freetocompute/kebe/generated/responses"
-	"github.com/freetocompute/kebe/pkg/assertions"
-	"github.com/freetocompute/kebe/pkg/auth"
-	dashboardRequests "github.com/freetocompute/kebe/pkg/dashboard/requests"
-	dashboardResponses "github.com/freetocompute/kebe/pkg/dashboard/responses"
 	"github.com/freetocompute/kebe/pkg/database"
 	"github.com/freetocompute/kebe/pkg/middleware"
-	"github.com/freetocompute/kebe/pkg/models"
-	"github.com/freetocompute/kebe/pkg/objectstore"
-	"github.com/freetocompute/kebe/pkg/sha"
-	"github.com/freetocompute/kebe/pkg/snap"
-	"github.com/freetocompute/kebe/pkg/store/requests"
-	"github.com/freetocompute/kebe/pkg/store/responses"
+	storeRequests "github.com/freetocompute/kebe/pkg/store/requests"
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-	"github.com/minio/minio-go/v7"
 	"github.com/sirupsen/logrus"
-	"github.com/snapcore/snapd/asserts"
 	"github.com/spf13/viper"
-	"gopkg.in/macaroon.v2"
 	"gorm.io/gorm"
-	"gorm.io/gorm/clause"
 )
 
 type Server struct {
-	engine *gin.Engine
-	port   int
-	db     *gorm.DB
+	engine  *gin.Engine
+	port    int
+	db      *gorm.DB
+	handler IDashboardHandler
 }
 
 func (s *Server) Init() {
@@ -74,248 +64,45 @@ func (s *Server) Init() {
 
 	db, _ := database.CreateDatabase()
 	s.db = db
-
-	s.SetupEndpoints(r)
-
+	s.handler = NewDashboardHandler(repositories.NewAccountRepository(db), repositories.NewSnapsRepository(db))
 	s.port = dashboardPort
 	s.engine = r
+
+	s.SetupEndpoints()
 }
 
 func (s *Server) Run() {
 	_ = s.engine.Run(fmt.Sprintf(":%d", s.port))
 }
 
+func (s *Server) getAccount(c *gin.Context) {
+	accountEmail := c.GetString("email")
+	if accountEmail != "" {
+		accountInfo, err := s.handler.GetAccount(accountEmail)
+		if err == nil {
+			c.JSON(http.StatusOK, &accountInfo)
+			return
+		}
+	}
+}
+
 func (s *Server) postACL(c *gin.Context) {
-	var requestACL dashboardRequests.ACLRequest
 	bodyBytes, _ := io.ReadAll(c.Request.Body)
 	bodyString := string(bodyBytes)
-	_ = json.Unmarshal(bodyBytes, &requestACL)
 
-	rootKeyString := config.MustGetString(configkey.MacaroonRootKey)
-	rootMacaroonId := config.MustGetString(configkey.MacaroonRootId)
-	rootMacaroonLocation := config.MustGetString(configkey.MacaroonRootLocation)
-	m := auth.MustNewMacaroon([]byte(rootKeyString), []byte(rootMacaroonId), rootMacaroonLocation, macaroon.V1)
-
-	dischargeKeyString := viper.GetString(configkey.MacaroonDischargeKey)
-	if len(dischargeKeyString) == 0 {
-		// this is panic worthy
-		panic(errors.New("discharge key must be set"))
-	}
-	thirdPartyCaveatId := config.MustGetString(configkey.MacaroonThirdPartyCaveatId)
-	thirdPartLocation := config.MustGetString(configkey.MacaroonThirdPartyLocation)
-	err := m.AddThirdPartyCaveat([]byte(dischargeKeyString), []byte(thirdPartyCaveatId), thirdPartLocation)
-	if err != nil {
-		panic(err)
-	}
-
-	_ = m.AddFirstPartyCaveat([]byte(bodyString))
-
-	ser, _ := auth.MacaroonSerialize(m)
-	mac := &dashboardResponses.Macaroon{Macaroon: ser}
-	c.JSON(200, mac)
-}
-
-func (s *Server) getAccount(c *gin.Context) {
-	accountUn, exists := c.Get("account")
-	if exists {
-		account, ok := accountUn.(*models.Account)
-		logrus.Tracef("Account: %+v", account)
-		var accountPreloaded models.Account
-		s.db.Where(&models.Account{AccountId: account.AccountId}).Preload(clause.Associations).Find(&accountPreloaded)
-		logrus.Tracef("Account: %+v", accountPreloaded)
-
-		if ok {
-			accountInfoResponse := dashboardResponses.AccountInfo{
-				AccountId:   account.AccountId,
-				Snaps:       map[string]map[string]dashboardResponses.Snap{},
-				AccountKeys: []dashboardResponses.Key{},
-			}
-
-			for _, k := range accountPreloaded.Keys {
-				accountInfoResponse.AccountKeys = append(accountInfoResponse.AccountKeys, dashboardResponses.Key{
-					PublicKeySHA384: k.SHA3384,
-					Name:            k.Name,
-				})
-			}
-
-			snaps := map[string]dashboardResponses.Snap{}
-			for _, s := range accountPreloaded.SnapEntries {
-				// TODO: replace with real data
-				snaps[s.Name] = dashboardResponses.Snap{
-					Status:  "Approved",
-					SnapId:  s.SnapStoreID,
-					Store:   "Global",
-					Since:   "2016-07-04T23:37:52Z",
-					Private: false,
-				}
-			}
-
-			accountInfoResponse.Snaps["16"] = snaps
-
-			logrus.Tracef("accountInfoResponse: %+v", accountInfoResponse)
-
-			json, _ := json.Marshal(&accountInfoResponse)
-			logrus.Tracef(string(json))
-
-			// TODO: this would actually need to be filled in
-			c.JSON(http.StatusOK, &accountInfoResponse)
-		}
-	}
-}
-
-// TODO: find a better place for this
-func GetAccount(c *gin.Context) *models.Account {
-	accountUn, exists := c.Get("account")
-	if exists {
-		account, ok := accountUn.(*models.Account)
-		if ok {
-			return account
-		}
-	}
-
-	return nil
-}
-
-func AddRisks(db *gorm.DB, snapEntryId uint, trackId uint) {
-	// TODO: fix me
-	risks := []string{"stable", "candidate", "beta", "edge"}
-
-	// TODO: fix the need for an empty revision
-	snapRevision := models.SnapRevision{
-		SnapFilename: "",
-		SnapEntryID:  snapEntryId,
-		SHA3_384:     "",
-		Size:         0,
-	}
-
-	db.Save(&snapRevision)
-
-	for _, risk := range risks {
-		var snapRisk models.SnapRisk
-		snapRisk.SnapEntryID = snapEntryId
-		snapRisk.SnapTrackID = trackId
-		snapRisk.Name = risk
-
-		snapRisk.RevisionID = snapRevision.ID
-
-		db.Save(&snapRisk)
-	}
-}
-
-func (s *Server) registerSnapName(c *gin.Context) {
-	var registerSnapName dashboardRequests.RegisterSnapName
-	err := json.NewDecoder(c.Request.Body).Decode(&registerSnapName)
+	m, err := s.handler.GetACLMacaroon(bodyString)
 	if err == nil {
-		account := GetAccount(c)
-
-		var existingSnap models.SnapEntry
-		db := s.db.Where(&models.SnapEntry{Name: registerSnapName.Name}).Find(&existingSnap)
-		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-			c.AbortWithStatus(http.StatusConflict)
-		} else {
-			var newSnapEntry models.SnapEntry
-
-			isDryRun := false
-			dryRunString := c.Query("dry_run")
-			if len(dryRunString) == 0 {
-				isDryRun = false
-			}
-
-			if !isDryRun {
-				snapId := uuid.New()
-
-				newSnapEntry.SnapStoreID = snapId.String()
-				newSnapEntry.Name = registerSnapName.Name
-				newSnapEntry.AccountID = account.ID
-				newSnapEntry.Type = "app"
-
-				s.db.Save(&newSnapEntry)
-
-				// For now when we register a snap we are going to create the default tracks/risks
-				track := models.SnapTrack{
-					Name:        "latest",
-					SnapEntryID: newSnapEntry.ID,
-				}
-
-				s.db.Save(&track)
-
-				AddRisks(s.db, newSnapEntry.ID, track.ID)
-
-				c.JSON(200, &dashboardResponses.RegisterSnap{
-					Id:   newSnapEntry.SnapStoreID,
-					Name: newSnapEntry.Name,
-				})
-			} else {
-				newSnapEntry.Name = registerSnapName.Name
-				c.JSON(200, &dashboardResponses.RegisterSnap{
-					Name: registerSnapName.Name,
-				})
-			}
-		}
-	}
-
-	logrus.Error(err)
-	c.AbortWithStatus(http.StatusInternalServerError)
-}
-
-func (s *Server) addAccountKey(c *gin.Context) {
-	account := GetAccount(c)
-
-	var accountKeyCreationRequest dashboardRequests.AccountKeyCreateRequest
-	err := json.NewDecoder(c.Request.Body).Decode(&accountKeyCreationRequest)
-	if err != nil {
-		logrus.Error(err)
-		c.AbortWithStatus(http.StatusBadRequest)
+		ser, _ := auth.MacaroonSerialize(m)
+		mac := &responses.Macaroon{Macaroon: ser}
+		c.JSON(200, mac)
 		return
 	}
 
-	if accountKeyCreationRequest.AccountKeyRequest == "" {
-		c.Data(http.StatusBadRequest, "text", []byte("The account key assertion string cannot be empty"))
-		return
-	}
-
-	assertion, err := asserts.Decode([]byte(accountKeyCreationRequest.AccountKeyRequest))
-	if err != nil {
-		c.Data(http.StatusBadRequest, "text", []byte(err.Error()))
-		return
-	}
-
-	if ass, ok := assertion.(*asserts.AccountKeyRequest); ok {
-		logrus.Infof("Account key public key id: %s", ass.PublicKeyID())
-
-		pubKey, err := assertions.GetPublicKeyFromBody(ass.Body())
-		if err != nil {
-			panic(err)
-		}
-
-		encodedPublicKey, err := asserts.EncodePublicKey(pubKey)
-		if err != nil {
-			panic(err)
-		}
-
-		pubKeyEncodedString := base64.StdEncoding.EncodeToString(encodedPublicKey)
-		accountKeyToAdd := models.Key{
-			Name:             ass.Name(),
-			SHA3384:          ass.PublicKeyID(),
-			AccountID:        account.ID,
-			EncodedPublicKey: pubKeyEncodedString,
-		}
-
-		s.db.Save(&accountKeyToAdd)
-
-		c.JSON(http.StatusOK, struct {
-			PublicKey string
-		}{
-			PublicKey: ass.PublicKeyID(),
-		})
-		return
-	}
-
-	c.Data(http.StatusBadRequest, "text", []byte("Assertion type wrong, or invalid."))
+	c.Status(http.StatusInternalServerError)
 }
 
 func (s *Server) pushSnap(c *gin.Context) {
-	var pushSnap requests.SnapPush
+	var pushSnap storeRequests.SnapPush
 	err := json.NewDecoder(c.Request.Body).Decode(&pushSnap)
 	if err == nil {
 		if pushSnap.DryRun {
@@ -324,44 +111,18 @@ func (s *Server) pushSnap(c *gin.Context) {
 			return
 		}
 
-		// TODO: implement xdelta3 handling
-		// TODO: while this is not supported, the unscanned bucket could become litered with xdelta3 files
+		//// TODO: implement xdelta3 handling
+		//// TODO: while this is not supported, the unscanned bucket could become litered with xdelta3 files
 		if pushSnap.DeltaFormat != "" {
 			c.AbortWithStatus(http.StatusInternalServerError)
 			return
 		}
 
-		var snap models.SnapEntry
-		db := s.db.Where(&models.SnapEntry{Name: pushSnap.Name}).Find(&snap)
-		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-			snapUpload := models.SnapUpload{
-				Name:        snap.Name,
-				UpDownID:    pushSnap.UpDownId,
-				Filesize:    uint(pushSnap.BinaryFileSize),
-				SnapEntryID: snap.ID,
-			}
-
-			logrus.Infof("Uploading: %+v", snapUpload)
-
-			// TODO: fix lazy
-			if len(pushSnap.Channels) > 0 {
-				channels := ""
-				for _, chn := range pushSnap.Channels {
-					channels = channels + "," + chn
-				}
-
-				snapUpload.Channels = channels
-			}
-
-			s.db.Save(&snapUpload)
-
-			// File saved successfully. Return proper result
-			// TODO: this URL needs to be serviced by a worker thread
-			c.JSON(http.StatusAccepted, &responses.Upload{
-				Success:          true,
-				StatusDetailsURL: config.MustGetString(configkey.DashboardURL) + "/dev/api/snap-status/" + pushSnap.UpDownId,
-			})
-
+		uploadResp, err2 := s.handler.PushSnap(pushSnap.Name, pushSnap.UpDownId, uint(pushSnap.BinaryFileSize), pushSnap.Channels)
+		if err2 == nil && uploadResp != nil {
+			//	// File saved successfully. Return proper result
+			//	// TODO: this URL needs to be serviced by a worker thread
+			c.JSON(http.StatusAccepted, uploadResp)
 			return
 		}
 	}
@@ -371,217 +132,36 @@ func (s *Server) pushSnap(c *gin.Context) {
 	c.AbortWithStatus(http.StatusInternalServerError)
 }
 
-func (s *Server) updateMeta(metaBytes *[]byte) {
-	snapMeta, err2 := snap.GetSnapMetaFromBytes(*metaBytes, "/tmp")
-	if err2 == nil {
-		logrus.Tracef("snapMeta: %+v", snapMeta)
-		var snapEntry models.SnapEntry
-		db := s.db.Where(&models.SnapEntry{Name: snapMeta.Name}).Find(&snapEntry)
-		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-			snapEntry.Type = "app"
-			if snapMeta.Type != "" {
-				snapEntry.Type = snapMeta.Type
-			} else {
-				logrus.Warnf("Snap %s had an emtpy type from its metadata, using default '%s'", snapEntry.Name, snapEntry.Type)
-			}
-
-			snapEntry.Confinement = snapMeta.Confinement
-			snapEntry.Base = snapMeta.Base
-
-			s.db.Save(&snapEntry)
-		} else {
-			logrus.Errorf("No rows found for: %s", snapMeta.Name)
-		}
-	} else {
-		logrus.Errorf("Unable to update snap meta: %s", err2)
-	}
-}
-
 // The id here is the up-down id generated from the upload to /unscanned-upload/
 func (s *Server) getStatus(c *gin.Context) {
 	// TODO: Do whatever we need to here and then return that it's processed, some day, (hopefully!) this will need to be async!
 	snapUpDownId := c.Param("id")
 
-	// We need to move the snap from the unscanned bucket to the snaps bucket
-	var snapUpload models.SnapUpload
-	db := s.db.Where(&models.SnapUpload{UpDownID: snapUpDownId}).Find(&snapUpload)
-	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-		snapFileName := snapUpDownId + ".snap"
-
-		// get the sha3_384 of the file so we can figure out if it already exists as a revision
-		obj, err := objectstore.GetMinioClient().GetObject(context.Background(), "unscanned", snapFileName, minio.GetObjectOptions{})
-		if err != nil {
-			panic(err)
-		}
-
-		bytes, err := io.ReadAll(obj)
-		h := crypto.SHA3_384.New()
-		if err != nil {
-			panic(err)
-		}
-		h.Write(bytes)
-		actualSha3 := fmt.Sprintf("%x", h.Sum(nil))
-
-		var revision models.SnapRevision
-		db = s.db.Where(models.SnapRevision{SHA3_384: actualSha3}).Find(&revision)
-		if _, ok = database.CheckDBForErrorOrNoRows(db); ok {
-			logrus.Infof("Revision %s found to exist for snap %s, updating channels with existing revision", actualSha3, snapUpload.Name)
-			// This revision already exists on some channel, we just
-			// need to update the requested channels to have this revision
-
-			// need to discard upload. remove record
-			// TODO: add to auditing later?
-			logrus.Infof("Removing object %s from buckect %s", snapFileName, "unscanned")
-			err2 := objectstore.GetMinioClient().RemoveObject(context.Background(), "unscanned", snapFileName, minio.RemoveObjectOptions{})
-			if err2 != nil {
-				logrus.Error(err2)
-			}
-		} else {
-			logrus.Infof("Revision %s not found to exist for snap %s, creating revision and updating channels with revision", actualSha3, snapUpload.Name)
-			objStore := objectstore.NewObjectStore()
-			err = objStore.Move("unscanned", "snaps", snapFileName)
-			if err != nil {
-				logrus.Error(err)
-				c.AbortWithStatus(http.StatusInternalServerError)
-				return
-			}
-
-			digest, _, err2 := sha.SnapFileSHA3_384FromReader(bytes2.NewReader(bytes))
-			if err2 != nil {
-				panic(err2)
-			}
-
-			revision = models.SnapRevision{
-				SnapFilename:   snapFileName,
-				SnapEntryID:    snapUpload.SnapEntryID,
-				SHA3_384:       actualSha3,
-				SHA3384Encoded: digest,
-				Size:           int64(snapUpload.Filesize),
-			}
-
-			s.db.Save(&revision)
-
-			s.updateMeta(&bytes)
-		}
-
-		// TODO: fix lazy
-		channels := strings.Split(snapUpload.Channels, ",")
-		err = s.releaseSnap(channels, snapUpload.SnapEntryID, revision.ID)
-		if err == nil {
-			c.JSON(http.StatusOK, &dashboardResponses.Status{
-				Processed: true,
-				Code:      "ready_to_release",
-				Revision:  int(revision.ID),
-			})
-
-			return
-		}
-
-		logrus.Error(err)
+	resp, err := s.handler.GetUploadStatus(snapUpDownId)
+	if err == nil && resp != nil {
+		c.JSON(http.StatusOK, resp)
+		return
+	} else if err != nil {
+		logrus.Errorf("Error getting status: %s", err)
 	}
 
 	c.AbortWithStatus(http.StatusInternalServerError)
 }
 
-func (s *Server) releaseSnap(channels []string, snapEntryId uint, revisionId uint) error {
-	var trackForRelease string
-	var riskForRelease string
-	for _, cn := range channels {
-		// It's possible this comes in the form:
-		//   - single string values "edge" where the track is assumed to be "latest" there is no branch
-		//   - two values "latest/edge" where the risk is proceeded by the track
-		//   - three values "latest/edge/some_branch"
-		parts := strings.Split(cn, "/")
-		if len(parts) == 1 {
-			riskForRelease = parts[0]
-			trackForRelease = "latest"
-		} else if len(parts) == 2 {
-			trackForRelease = parts[0]
-			riskForRelease = parts[1]
-		} else if len(parts) == 3 {
-			return errors.New("branches not supported yet")
-		}
-
-		// get all the tracks
-		var track models.SnapTrack
-		db := s.db.Where(&models.SnapTrack{SnapEntryID: snapEntryId, Name: trackForRelease}).Find(&track)
-		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-			// get all the risks
-			var risk models.SnapRisk
-			db = s.db.Where(&models.SnapRisk{SnapEntryID: snapEntryId, Name: riskForRelease, SnapTrackID: track.ID}).Find(&risk)
-			if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-				var revision models.SnapRevision
-				db = s.db.Where("id", revisionId).Find(&revision)
-				if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-					risk.RevisionID = revision.ID
-					s.db.Save(&risk)
-				}
-			}
-		}
-	}
-
-	return nil
-}
-
 func (s *Server) snapRelease(c *gin.Context) {
-	var snapRelease requests.SnapRelease
-	err := json.NewDecoder(c.Request.Body).Decode(&snapRelease)
+	var rel storeRequests.SnapRelease
+	err := json.NewDecoder(c.Request.Body).Decode(&rel)
 	if err == nil {
-		var snapEntry models.SnapEntry
-		db := s.db.Where(&models.SnapEntry{Name: snapRelease.Name}).Find(&snapEntry)
-		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		revision, err2 := strconv.Atoi(rel.Revision)
+		if err2 != nil {
+			logrus.Error(err2)
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
 
-			var trackForRelease string
-			var riskForRelease string
-			for _, cn := range snapRelease.Channels {
-				// It's possible this comes in the form:
-				//   - single string values "edge" where the track is assumed to be "latest" there is no branch
-				//   - two values "latest/edge" where the risk is proceeded by the track
-				//   - three values "latest/edge/some_branch"
-				parts := strings.Split(cn, "/")
-				if len(parts) == 1 {
-					riskForRelease = parts[0]
-					trackForRelease = "latest"
-				} else if len(parts) == 2 {
-					trackForRelease = parts[0]
-					riskForRelease = parts[1]
-				} else if len(parts) == 3 {
-					logrus.Error(errors.New("branches not supported yet"))
-					c.AbortWithStatus(http.StatusInternalServerError)
-					return
-				}
-
-				// get all the tracks
-				var track models.SnapTrack
-				db = s.db.Where(&models.SnapTrack{SnapEntryID: snapEntry.ID, Name: trackForRelease}).Find(&track)
-				if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-					// get all the risks
-					var risk models.SnapRisk
-					db = s.db.Where(&models.SnapRisk{SnapEntryID: snapEntry.ID, Name: riskForRelease, SnapTrackID: track.ID}).Find(&risk)
-					if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-						revisionNumber, err := strconv.Atoi(snapRelease.Revision)
-						if err != nil {
-							logrus.Error(err)
-							c.AbortWithStatus(http.StatusInternalServerError)
-							return
-						}
-
-						var revision models.SnapRevision
-						db = s.db.Where("id", revisionNumber).Find(&revision)
-						if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-							risk.RevisionID = revision.ID
-							s.db.Save(&risk)
-						}
-					} else {
-						// TODO: we need to just create it if it didn't already exist
-						logrus.Errorf("Track %s for %s with risk %s does not exist, it needs to be created!", track.Name, snapEntry.Name, risk.Name)
-						c.AbortWithStatus(http.StatusInternalServerError)
-						return
-					}
-				}
-			}
-
-			c.JSON(http.StatusOK, &dashboardResponses.SnapRelease{Success: true})
+		released, err2 := s.handler.ReleaseSnap(rel.Name, uint(revision), rel.Channels)
+		if err2 == nil {
+			c.JSON(http.StatusOK, &responses.SnapRelease{Success: released})
 			return
 		}
 	} else {
@@ -593,123 +173,116 @@ func (s *Server) snapRelease(c *gin.Context) {
 
 func (s *Server) getSnapChannelMap(c *gin.Context) {
 	snapName := c.Param("snap")
-	var snap models.SnapEntry
-	db := s.db.Where(&models.SnapEntry{Name: snapName}).Find(&snap)
-	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-		var root generatedResponses.Root
-		var channelMapItems []*generatedResponses.ChannelMapItems
-		var revisions []*generatedResponses.RevisionsItems
-		var channelItems []*generatedResponses.ChannelsItems
-		var snapTracks []*generatedResponses.TracksItems
-
-		logrus.Tracef("Getting tracks for: %s", snap.Name)
-
-		var tracks []models.SnapTrack
-		db := s.db.Where(&models.SnapTrack{SnapEntryID: snap.ID}).Find(&tracks)
-		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-			for _, track := range tracks {
-
-				snapTracks = append(snapTracks, &generatedResponses.TracksItems{
-					Name: track.Name,
-				})
-
-				logrus.Tracef("Getting risks for track: %s", track.Name)
-
-				var risks []models.SnapRisk
-				db := s.db.Where(&models.SnapRisk{SnapEntryID: snap.ID, SnapTrackID: track.ID}).Find(&risks)
-				if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-					for _, risk := range risks {
-						var revision models.SnapRevision
-
-						logrus.Tracef("Getting revision for risk: %s", risk.Name)
-
-						db := s.db.Where("id", risk.RevisionID).Find(&revision)
-						if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-
-							logrus.Tracef("Got revision %d", revision.ID)
-
-							channelMapItems = append(channelMapItems, &generatedResponses.ChannelMapItems{
-								Architecture: "amd64",
-								Channel:      track.Name + "/" + risk.Name,
-								Revision:     int(revision.ID),
-								Progressive:  &generatedResponses.Progressive{},
-							})
-
-							revisions = append(revisions, &generatedResponses.RevisionsItems{
-								Architectures: []string{"amd64"},
-								Revision:      int(revision.ID),
-								Version:       "1",
-								Attributes:    &generatedResponses.Attributes{},
-								Confinement:   "strict",
-								Epoch:         &generatedResponses.Epoch{},
-								Grade:         "stable",
-								Sha3384:       revision.SHA3_384,
-								Size:          int(revision.Size),
-							})
-
-							channelItems = append(channelItems, &generatedResponses.ChannelsItems{
-								Name:  track.Name + "/" + risk.Name,
-								Risk:  risk.Name,
-								Track: track.Name,
-							})
-						}
-					}
-				}
-			}
-		}
-
-		root.ChannelMap = channelMapItems
-		root.Revisions = revisions
-
-		root.Snap = &generatedResponses.Snap{
-			Channels: channelItems,
-			Name:     snap.Name,
-			Tracks:   snapTracks,
-		}
-
-		c.JSON(http.StatusOK, &root)
+	channelMapRoot, err := s.handler.GetSnapChannelMap(snapName)
+	if err == nil && channelMapRoot != nil {
+		c.JSON(http.StatusOK, channelMapRoot)
 		return
+	} else if err != nil {
+		logrus.Error(err)
+	} else {
+		// logrus.Error("unknown error encountered")
+		panic("unknown error encountered")
 	}
 
 	c.AbortWithStatus(http.StatusInternalServerError)
 }
 
 func (s *Server) verifyACL(c *gin.Context) {
-	var verify dashboardRequests.Verify
+	var verify requests.Verify
 	err := json.NewDecoder(c.Request.Body).Decode(&verify)
 	if err != nil {
 		c.AbortWithStatus(http.StatusInternalServerError)
 		return
 	}
 
-	user, err := middleware.VerifyAndGetUser(s.db, verify.AuthData.Authorization)
-	if err != nil {
-		log.Fatalln(err)
-		c.AbortWithStatus(http.StatusInternalServerError)
-		return
+	response, err := s.handler.VerifyACL(&verify)
+	if err == nil && response != nil {
+		c.JSON(http.StatusOK, &response)
+	} else if err != nil {
+		logrus.Error(err)
 	}
 
-	if user != nil {
-		v := dashboardResponses.Verify{
-			Allowed:               true,
-			DeviceRefreshRequired: false,
-			RefreshRequired:       false,
-			Account: &dashboardResponses.VerifyAccount{
-				Email:       user.Email,
-				DisplayName: user.DisplayName,
-				OpenId:      "oid1234",
-				Verified:    true,
-			},
-			Device:      nil,
-			LastAuth:    "2016-05-26T12:53:23Z",
-			Permissions: &[]string{"package_access", "package_manage", "package_push", "package_register", "package_release", "package_update"},
-			SnapIds:     nil,
-			Channels:    nil,
+	c.Status(http.StatusInternalServerError)
+}
+
+func (s *Server) registerSnapName(c *gin.Context) {
+	var registerSnapName requests.RegisterSnapName
+	err := json.NewDecoder(c.Request.Body).Decode(&registerSnapName)
+	if err == nil {
+		accountEmail := c.GetString("email")
+
+		isDryRun := false
+		dryRunString := c.Query("dry_run")
+		if len(dryRunString) != 0 {
+			dryRun, err2 := strconv.ParseBool(dryRunString)
+			if err2 == nil {
+				isDryRun = dryRun
+			}
 		}
 
-		c.JSON(http.StatusOK, &v)
-		return
+		resp, err2 := s.handler.RegisterSnapName(accountEmail, isDryRun, registerSnapName.Name)
+		if err2 == nil && resp != nil {
+			c.JSON(http.StatusOK, resp)
+		}
+	} else {
+		logrus.Error(err)
 	}
 
 	c.AbortWithStatus(http.StatusInternalServerError)
+}
+
+func (s *Server) addAccountKey(c *gin.Context) {
+	accountEmail := c.GetString("email")
+	if accountEmail != "" {
+		var accountKeyCreationRequest requests.AccountKeyCreateRequest
+		err := json.NewDecoder(c.Request.Body).Decode(&accountKeyCreationRequest)
+		if err != nil {
+			logrus.Error(err)
+			c.AbortWithStatus(http.StatusBadRequest)
+			return
+		}
+
+		if accountKeyCreationRequest.AccountKeyRequest == "" {
+			c.Data(http.StatusBadRequest, "text", []byte("The account key assertion string cannot be empty"))
+			return
+		}
+
+		assertion, err := asserts.Decode([]byte(accountKeyCreationRequest.AccountKeyRequest))
+		if err != nil {
+			c.Data(http.StatusBadRequest, "text", []byte(err.Error()))
+			return
+		}
+
+		if ass, ok := assertion.(*asserts.AccountKeyRequest); ok {
+			logrus.Infof("Account key public key id: %s", ass.PublicKeyID())
+
+			pubKey, err2 := assertions.GetPublicKeyFromBody(ass.Body())
+			if err2 != nil {
+				panic(err2)
+			}
+
+			encodedPublicKey, err2 := asserts.EncodePublicKey(pubKey)
+			if err2 != nil {
+				panic(err2)
+			}
+
+			pubKeyEncodedString := base64.StdEncoding.EncodeToString(encodedPublicKey)
+
+			acct, err2 := s.handler.AddAccountKey(accountEmail, ass.Name(), ass.PublicKeyID(), pubKeyEncodedString)
+			if err2 == nil && acct != nil {
+				c.JSON(http.StatusOK, struct {
+					PublicKey string
+				}{
+					PublicKey: ass.PublicKeyID(),
+				})
+				return
+			} else if err2 != nil {
+				logrus.Error(err2)
+			}
+
+			c.Status(http.StatusInternalServerError)
+		}
+	}
+
+	c.Data(http.StatusBadRequest, "text", []byte("Assertion type wrong, or invalid."))
 }

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -3,20 +3,19 @@ package middleware
 import (
 	"errors"
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/freetocompute/kebe/config"
 	"github.com/freetocompute/kebe/config/configkey"
 	"github.com/freetocompute/kebe/pkg/auth"
-	"github.com/freetocompute/kebe/pkg/database"
-	"github.com/freetocompute/kebe/pkg/models"
 	"github.com/gin-gonic/gin"
 	"github.com/sirupsen/logrus"
 	"gopkg.in/macaroon.v2"
 	"gorm.io/gorm"
-	"net/http"
-	"strings"
 )
 
-func VerifyAndGetUser(db *gorm.DB, authData string) (*models.Account, error) {
+func VerifyAndGetEmail(authData string) (*string, error) {
 	rootKey := config.MustGetString(configkey.MacaroonRootKey)
 
 	rootS, dischargeS := GetRootMacaroonsFromString(authData)
@@ -54,11 +53,12 @@ func VerifyAndGetUser(db *gorm.DB, authData string) (*models.Account, error) {
 				}
 
 				// find an account for this discharge token
-				var userAccount models.Account
-				db := db.Where(&models.Account{Email: email}).Find(&userAccount)
-				if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-					return &userAccount, nil
-				}
+				//var userAccount models.Account
+				//db := db.Where(&models.Account{Email: email}).Find(&userAccount)
+				//if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+				//	return &userAccount, nil
+				//}
+				return &email, nil
 			}
 		}
 	}
@@ -105,14 +105,9 @@ func CheckForAuthorizedUserWithMacaroons(db *gorm.DB, rootKey string) gin.Handle
 						}
 					}
 
-					// find an account for this discharge token
-					var userAccount models.Account
-					db := db.Where(&models.Account{Email: email}).Find(&userAccount)
-					if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
-						c.Set("account", &userAccount)
-						c.Next()
-						return
-					}
+					c.Set("email", email)
+					c.Next()
+					return
 				}
 			}
 		}

--- a/pkg/repositories/account.go
+++ b/pkg/repositories/account.go
@@ -3,13 +3,16 @@ package repositories
 import (
 	"github.com/freetocompute/kebe/pkg/database"
 	"github.com/freetocompute/kebe/pkg/models"
+	"github.com/sirupsen/logrus"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
 
 type IAccountRepository interface {
 	GetAccountByEmail(email string, preload bool) (*models.Account, error)
+	GetAccountById(accountId string, preload bool) (*models.Account, error)
 	AddKey(name string, SHA3384 string, encodedPublicKey string, accountEmail string) (*models.Key, error)
+	GetKeyBySHA3384(sha3384 string) (*models.Key, error)
 }
 
 type AccountRepository struct {
@@ -18,6 +21,16 @@ type AccountRepository struct {
 
 func NewAccountRepository(db *gorm.DB) *AccountRepository {
 	return &AccountRepository{db: db}
+}
+
+func (a *AccountRepository) GetKeyBySHA3384(sha3384 string) (*models.Key, error) {
+	whereModel := &models.Key{SHA3384: sha3384}
+	return a.getKeyByWhereModel(whereModel, true)
+}
+
+func (a *AccountRepository) GetAccountById(accountId string, preload bool) (*models.Account, error) {
+	whereModel := &models.Account{AccountId: accountId}
+	return a.getAccountByWhereModel(whereModel, preload)
 }
 
 func (a *AccountRepository) GetAccountByEmail(email string, preload bool) (*models.Account, error) {
@@ -51,4 +64,42 @@ func (a *AccountRepository) AddKey(name string, SHA3384 string, encodedPublicKey
 	}
 
 	return nil, err
+}
+
+func (a *AccountRepository) getKeyByWhereModel(whereModel *models.Key, preload bool) (*models.Key, error) {
+	var accountKey models.Key
+	var db *gorm.DB
+	if preload {
+		db = a.db.Where(whereModel).Preload(clause.Associations).Find(&accountKey)
+	} else {
+		db = a.db.Where(whereModel).Find(&accountKey)
+	}
+
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &accountKey, nil
+	} else if db.Error != nil {
+		return nil, db.Error
+	}
+
+	logrus.Warningf("Account key not found: %+v", whereModel)
+	return nil, nil
+}
+
+func (a *AccountRepository) getAccountByWhereModel(whereModel *models.Account, preload bool) (*models.Account, error) {
+	var userAccount models.Account
+	var db *gorm.DB
+	if preload {
+		db = a.db.Where(whereModel).Preload(clause.Associations).Find(&userAccount)
+	} else {
+		db = a.db.Where(whereModel).Find(&userAccount)
+	}
+
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &userAccount, nil
+	} else if db.Error != nil {
+		return nil, db.Error
+	}
+
+	logrus.Warningf("Account not found: %+v", whereModel)
+	return nil, nil
 }

--- a/pkg/repositories/account.go
+++ b/pkg/repositories/account.go
@@ -1,0 +1,54 @@
+package repositories
+
+import (
+	"github.com/freetocompute/kebe/pkg/database"
+	"github.com/freetocompute/kebe/pkg/models"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+type IAccountRepository interface {
+	GetAccountByEmail(email string, preload bool) (*models.Account, error)
+	AddKey(name string, SHA3384 string, encodedPublicKey string, accountEmail string) (*models.Key, error)
+}
+
+type AccountRepository struct {
+	db *gorm.DB
+}
+
+func NewAccountRepository(db *gorm.DB) *AccountRepository {
+	return &AccountRepository{db: db}
+}
+
+func (a *AccountRepository) GetAccountByEmail(email string, preload bool) (*models.Account, error) {
+	var userAccount models.Account
+	var db *gorm.DB
+	if preload {
+		db = a.db.Where(&models.Account{Email: email}).Preload(clause.Associations).Find(&userAccount)
+	} else {
+		db = a.db.Where(&models.Account{Email: email}).Find(&userAccount)
+	}
+
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &userAccount, nil
+	}
+
+	return nil, db.Error
+}
+
+func (a *AccountRepository) AddKey(name string, SHA3384 string, encodedPublicKey string, email string) (*models.Key, error) {
+	acct, err := a.GetAccountByEmail(email, false)
+	if err == nil && acct != nil {
+		accountKeyToAdd := models.Key{
+			Name:             name,
+			SHA3384:          SHA3384,
+			AccountID:        acct.ID,
+			EncodedPublicKey: encodedPublicKey,
+		}
+
+		a.db.Save(&accountKeyToAdd)
+		return &accountKeyToAdd, nil
+	}
+
+	return nil, err
+}

--- a/pkg/repositories/snaps.go
+++ b/pkg/repositories/snaps.go
@@ -1,0 +1,326 @@
+package repositories
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/freetocompute/kebe/pkg/snap"
+	"github.com/sirupsen/logrus"
+
+	"github.com/google/uuid"
+
+	"github.com/freetocompute/kebe/pkg/database"
+	"github.com/freetocompute/kebe/pkg/models"
+	"gorm.io/gorm"
+)
+
+type ISnapsRepository interface {
+	GetSnap(name string) (*models.SnapEntry, error)
+	AddSnap(name string, accountId uint) (*models.SnapEntry, error)
+
+	GetRevisionBySHA(SHA3_384 string) (*models.SnapRevision, error)
+	GetUpload(upDownId string) (*models.SnapUpload, error)
+	UpdateRevision(revision *models.SnapRevision, revisionBytes *[]byte) (*models.SnapRevision, error)
+
+	ReleaseSnap(channels []string, snapEntryId uint, revisionId uint) error
+	AddUpload(snapName string, upDownId string, size uint, channels []string) (*models.SnapUpload, error)
+
+	SetChannelRevision(trackName string, riskName string, revisionId uint, snapId uint) (*models.SnapTrack, error)
+
+	GetTracks(snapId uint) (*[]models.SnapTrack, error)
+	GetRisks(trackId uint) (*[]models.SnapRisk, error)
+	GetRevision(id uint) (*models.SnapRevision, error)
+}
+
+type SnapsRepository struct {
+	db *gorm.DB
+}
+
+func NewSnapsRepository(db *gorm.DB) *SnapsRepository {
+	return &SnapsRepository{db: db}
+}
+
+func (sp *SnapsRepository) GetTracks(snapId uint) (*[]models.SnapTrack, error) {
+	var tracks []models.SnapTrack
+	db := sp.db.Where(&models.SnapTrack{SnapEntryID: snapId}).Find(&tracks)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &tracks, nil
+	}
+
+	if db.Error != nil {
+		return nil, db.Error
+	}
+
+	logrus.Errorf("Could not find tracks for snapId: %d", snapId)
+	return nil, errors.New("unknown error encountered")
+}
+
+func (sp *SnapsRepository) GetRisks(trackId uint) (*[]models.SnapRisk, error) {
+	var risks []models.SnapRisk
+	db := sp.db.Where(&models.SnapRisk{SnapTrackID: trackId}).Find(&risks)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &risks, nil
+	}
+
+	if db.Error != nil {
+		return nil, db.Error
+	}
+
+	logrus.Errorf("Could not find risks for track id: %d", trackId)
+	return nil, errors.New("unknown error encountered")
+}
+
+func (sp *SnapsRepository) GetRevision(id uint) (*models.SnapRevision, error) {
+	var revision models.SnapRevision
+	db := sp.db.Where(&models.SnapRevision{Model: gorm.Model{ID: id}}).Find(&revision)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &revision, nil
+	}
+
+	if db.Error != nil {
+		return nil, db.Error
+	}
+
+	return nil, errors.New("unknown error encountered")
+}
+
+func (sp *SnapsRepository) SetChannelRevision(trackName string, riskName string, revisionId uint, snapId uint) (*models.SnapTrack, error) {
+	// get all the tracks
+	var track models.SnapTrack
+	db := sp.db.Where(&models.SnapTrack{SnapEntryID: snapId, Name: trackName}).Find(&track)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		// get all the risks
+		var risk models.SnapRisk
+		db = sp.db.Where(&models.SnapRisk{SnapEntryID: snapId, Name: riskName, SnapTrackID: track.ID}).Find(&risk)
+		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+			var revision models.SnapRevision
+			db = sp.db.Where("id", revisionId).Find(&revision)
+			if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+				risk.RevisionID = revision.ID
+				sp.db.Save(&risk)
+				return &track, nil
+			}
+		} else {
+			return nil, errors.New("risk does not exist for track")
+		}
+	} else {
+		return nil, errors.New("track does not exist for snap")
+	}
+
+	return nil, errors.New("unknown error encountered")
+}
+
+func (sp *SnapsRepository) AddUpload(snapName string, upDownId string, fileSize uint, channels []string) (*models.SnapUpload, error) {
+	var snap models.SnapEntry
+	db := sp.db.Where(&models.SnapEntry{Name: snapName}).Find(&snap)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		snapUpload := models.SnapUpload{
+			Name:        snapName,
+			UpDownID:    upDownId,
+			Filesize:    fileSize,
+			SnapEntryID: snap.ID,
+		}
+
+		logrus.Infof("Uploading: %+v", snapUpload)
+
+		// TODO: fix lazy; this should be converted to a table so that the channels can be stored separately or maybe redis
+		if len(channels) > 0 {
+			channelsString := ""
+			for _, chn := range channels {
+				if channelsString == "" {
+					channelsString = chn
+				} else {
+					channelsString = channelsString + "," + chn
+				}
+			}
+
+			snapUpload.Channels = channelsString
+		}
+
+		db2 := sp.db.Save(&snapUpload)
+		if _, ok := database.CheckDBForErrorOrNoRows(db2); ok {
+			return &snapUpload, nil
+		}
+	}
+
+	if db.Error != nil {
+		logrus.Error(db.Error)
+		return nil, db.Error
+	}
+
+	return nil, errors.New("unknown error encountered")
+}
+
+func (sp *SnapsRepository) GetRevisionBySHA(SHA3_384 string) (*models.SnapRevision, error) {
+	var revision models.SnapRevision
+	db := sp.db.Where(models.SnapRevision{SHA3_384: SHA3_384}).Find(&revision)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &revision, nil
+	} else if db.Error == nil {
+		return nil, nil
+	}
+
+	return nil, db.Error
+}
+
+func (sp *SnapsRepository) GetUpload(upDownId string) (*models.SnapUpload, error) {
+	var snapUpload models.SnapUpload
+	db := sp.db.Where(&models.SnapUpload{UpDownID: upDownId}).Find(&snapUpload)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &snapUpload, nil
+	}
+
+	return nil, errors.New("not found")
+}
+
+func (sp *SnapsRepository) UpdateRevision(revision *models.SnapRevision, revisionBytes *[]byte) (*models.SnapRevision, error) {
+	db := sp.db.Save(revision)
+	if db.Error == nil {
+		err := sp.updateMeta(revisionBytes)
+		if err == nil {
+			return revision, nil
+		}
+	}
+	return nil, db.Error
+}
+
+func (sp *SnapsRepository) GetSnap(name string) (*models.SnapEntry, error) {
+	var existingSnap models.SnapEntry
+	db := sp.db.Where(&models.SnapEntry{Name: name}).Find(&existingSnap)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &existingSnap, nil
+	}
+
+	if db.Error != nil {
+		return nil, db.Error
+	}
+
+	logrus.Errorf("Could not find snap %s", name)
+
+	return nil, db.Error
+}
+
+func (sp *SnapsRepository) AddSnap(name string, accountId uint) (*models.SnapEntry, error) {
+	existingSnap, err := sp.GetSnap(name)
+	if err == nil && existingSnap != nil {
+		// when adding a snap, not finding one _is_ (!ok) what you want
+		var newSnapEntry models.SnapEntry
+		snapId := uuid.New()
+		newSnapEntry.SnapStoreID = snapId.String()
+		newSnapEntry.Name = name
+		newSnapEntry.AccountID = accountId
+		newSnapEntry.Type = "app"
+
+		sp.db.Save(&newSnapEntry)
+
+		// For now when we register a snap we are going to create the default tracks/risks
+		track := models.SnapTrack{
+			Name:        "latest",
+			SnapEntryID: newSnapEntry.ID,
+		}
+
+		sp.db.Save(&track)
+
+		sp.addRisks(newSnapEntry.ID, track.ID)
+
+		return &newSnapEntry, nil
+	}
+
+	return nil, errors.New("there was an error")
+}
+
+func (sp *SnapsRepository) AddDefaultRisks(snapEntryId uint, trackId uint) {
+	sp.addRisks(snapEntryId, trackId)
+}
+
+func (sp *SnapsRepository) ReleaseSnap(channels []string, snapEntryId uint, revisionId uint) error {
+	var trackForRelease string
+	var riskForRelease string
+	for _, cn := range channels {
+		// It's possible this comes in the form:
+		//   - single string values "edge" where the track is assumed to be "latest" there is no branch
+		//   - two values "latest/edge" where the risk is proceeded by the track
+		//   - three values "latest/edge/some_branch"
+		parts := strings.Split(cn, "/")
+		if len(parts) == 1 {
+			riskForRelease = parts[0]
+			trackForRelease = "latest"
+		} else if len(parts) == 2 {
+			trackForRelease = parts[0]
+			riskForRelease = parts[1]
+		} else if len(parts) == 3 {
+			return errors.New("branches not supported yet")
+		}
+
+		// get all the tracks
+		var track models.SnapTrack
+		db := sp.db.Where(&models.SnapTrack{SnapEntryID: snapEntryId, Name: trackForRelease}).Find(&track)
+		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+			// get all the risks
+			var risk models.SnapRisk
+			db = sp.db.Where(&models.SnapRisk{SnapEntryID: snapEntryId, Name: riskForRelease, SnapTrackID: track.ID}).Find(&risk)
+			if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+				var revision models.SnapRevision
+				db = sp.db.Where("id", revisionId).Find(&revision)
+				if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+					risk.RevisionID = revision.ID
+					sp.db.Save(&risk)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func (sp *SnapsRepository) addRisks(snapEntryId uint, trackId uint) {
+	// TODO: fix me
+	risks := []string{"stable", "candidate", "beta", "edge"}
+
+	// TODO: fix the need for an empty revision
+	snapRevision := models.SnapRevision{
+		SnapFilename: "",
+		SnapEntryID:  snapEntryId,
+		SHA3_384:     "",
+		Size:         0,
+	}
+
+	sp.db.Save(&snapRevision)
+
+	for _, risk := range risks {
+		var snapRisk models.SnapRisk
+		snapRisk.SnapEntryID = snapEntryId
+		snapRisk.SnapTrackID = trackId
+		snapRisk.Name = risk
+
+		snapRisk.RevisionID = snapRevision.ID
+
+		sp.db.Save(&snapRisk)
+	}
+}
+
+func (sp *SnapsRepository) updateMeta(metaBytes *[]byte) error {
+	snapMeta, err2 := snap.GetSnapMetaFromBytes(*metaBytes, "/tmp")
+	if err2 == nil {
+		logrus.Tracef("snapMeta: %+v", snapMeta)
+		var snapEntry models.SnapEntry
+		db := sp.db.Where(&models.SnapEntry{Name: snapMeta.Name}).Find(&snapEntry)
+		if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+			snapEntry.Type = "app"
+			if snapMeta.Type != "" {
+				snapEntry.Type = snapMeta.Type
+			} else {
+				logrus.Warnf("Snap %s had an emtpy type from its metadata, using default '%s'", snapEntry.Name, snapEntry.Type)
+			}
+
+			snapEntry.Confinement = snapMeta.Confinement
+			snapEntry.Base = snapMeta.Base
+
+			sp.db.Save(&snapEntry)
+		} else {
+			logrus.Errorf("No rows found for: %s", snapMeta.Name)
+		}
+	}
+
+	return err2
+}

--- a/pkg/repositories/snaps.go
+++ b/pkg/repositories/snaps.go
@@ -30,6 +30,10 @@ type ISnapsRepository interface {
 	GetTracks(snapId uint) (*[]models.SnapTrack, error)
 	GetRisks(trackId uint) (*[]models.SnapRisk, error)
 	GetRevision(id uint) (*models.SnapRevision, error)
+
+	GetSections() (*[]string, error)
+
+	GetSnaps() (*[]models.SnapEntry, error)
 }
 
 type SnapsRepository struct {
@@ -38,6 +42,15 @@ type SnapsRepository struct {
 
 func NewSnapsRepository(db *gorm.DB) *SnapsRepository {
 	return &SnapsRepository{db: db}
+}
+
+func (sp *SnapsRepository) GetSections() (*[]string, error) {
+	// TODO: add these to the database for real
+	sections := []string{
+		"general",
+	}
+
+	return &sections, nil
 }
 
 func (sp *SnapsRepository) GetTracks(snapId uint) (*[]models.SnapTrack, error) {
@@ -181,6 +194,24 @@ func (sp *SnapsRepository) UpdateRevision(revision *models.SnapRevision, revisio
 			return revision, nil
 		}
 	}
+	return nil, db.Error
+}
+
+func (sp *SnapsRepository) GetSnaps() (*[]models.SnapEntry, error) {
+	var snaps []models.SnapEntry
+
+	// TODO: would need to implement private and filter here
+	db := sp.db.Find(&snaps)
+	if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		return &snaps, nil
+	}
+
+	// TODO: evaluate this, we shouldn't ever really have _NO_ snaps
+	// It's not an error to find no snaps... or is it?
+	if db.Error == nil {
+		return &snaps, nil
+	}
+
 	return nil, db.Error
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,11 +2,20 @@ package server
 
 import (
 	"context"
+	"io/ioutil"
+	"strings"
+	"sync"
+
+	"github.com/freetocompute/kebe/pkg/crypto"
+	"github.com/snapcore/snapd/asserts"
+	"github.com/snapcore/snapd/asserts/assertstest"
+
 	"github.com/freetocompute/kebe/config"
 	"github.com/freetocompute/kebe/config/configkey"
 	"github.com/freetocompute/kebe/pkg/database"
 	"github.com/freetocompute/kebe/pkg/middleware"
 	"github.com/freetocompute/kebe/pkg/objectstore"
+	"github.com/freetocompute/kebe/pkg/repositories"
 	"github.com/freetocompute/kebe/pkg/store"
 	"github.com/gin-gonic/gin"
 	"github.com/minio/minio-go/v7"
@@ -44,14 +53,40 @@ func (s *Server) Run() {
 
 	db, _ := database.CreateDatabase()
 
-	store := store.NewStore(db)
+	assertsDatabase := GetDatabaseWithRootKey()
+
+	obs := objectstore.NewObjectStore()
+	bytes, _ := obs.GetFileFromBucket("root", "private-key.pem")
+	rootPrivateKey, err := crypto.ParseRSAPrivateKeyFromPEM(*bytes)
+	if err != nil {
+		logrus.Error(err)
+		panic(err)
+	}
+
+	rootAuthorityId := config.MustGetString(configkey.RootAuthority)
+	signingDB := assertstest.NewSigningDB(rootAuthorityId, asserts.RSAPrivateKey(rootPrivateKey))
+
+	bytes, _ = obs.GetFileFromBucket("generic", "private-key.pem")
+	genericPrivateKey, err := crypto.ParseRSAPrivateKeyFromPEM(*bytes)
+	if err != nil {
+		logrus.Error(err)
+		panic(err)
+	}
+
+	err = signingDB.ImportKey(asserts.RSAPrivateKey(genericPrivateKey))
+	if err != nil {
+		panic(err)
+	}
+
+	handler := store.NewHandler(repositories.NewAccountRepository(db), repositories.NewSnapsRepository(db))
+	store := store.New(handler, assertsDatabase, rootPrivateKey, genericPrivateKey, signingDB)
 	if store == nil {
 		panic("store was not created, cannot continue")
 	}
 	store.SetupEndpoints(r)
 
 	// Make sure all the necessary buckets exists
-	err := objectstore.GetMinioClient().MakeBucket(context.Background(), "snaps", minio.MakeBucketOptions{})
+	err = objectstore.GetMinioClient().MakeBucket(context.Background(), "snaps", minio.MakeBucketOptions{})
 	if err != nil {
 		if _, ok := err.(minio.ErrorResponse); !ok {
 			panic(err)
@@ -66,4 +101,116 @@ func (s *Server) Run() {
 	}
 
 	_ = r.Run()
+}
+
+var databaseCreationMutex sync.Mutex
+
+func GetDatabaseWithRootKey() *asserts.Database {
+	minioClient := objectstore.GetMinioClient()
+
+	databaseCreationMutex.Lock()
+	defer databaseCreationMutex.Unlock()
+
+	return GetDatabaseWithRootKeyS3(minioClient)
+}
+
+func GetDatabaseWithRootKeyS3(minioClient *minio.Client) *asserts.Database {
+	databaseCfg, err := getDatabaseConfig(minioClient)
+	if err != nil {
+		panic(err)
+	}
+
+	db, err := asserts.OpenDatabase(databaseCfg)
+	if err != nil {
+		panic(err)
+	}
+
+	buckets := []string{"root", "generic"}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+
+	for _, bucket := range buckets {
+		objectCh := minioClient.ListObjects(ctx, bucket, minio.ListObjectsOptions{
+			Recursive: true,
+		})
+		for object := range objectCh {
+			if strings.Contains(object.Key, "pem") {
+				objectPtr, err2 := minioClient.GetObject(ctx, bucket, object.Key, minio.GetObjectOptions{})
+				if err2 != nil {
+					panic(err2)
+				}
+				bytes, _ := ioutil.ReadAll(objectPtr)
+
+				rsaPK, err2 := crypto.ParseRSAPrivateKeyFromPEM(bytes)
+				if err2 != nil {
+					panic(err)
+				}
+
+				assertPK := asserts.RSAPrivateKey(rsaPK)
+
+				err2 = db.ImportKey(assertPK)
+				if err2 != nil {
+					panic(err)
+				}
+			}
+		}
+	}
+
+	return db
+}
+
+func getDatabaseConfig(minioClient *minio.Client) (*asserts.DatabaseConfig, error) {
+	var trusted []asserts.Assertion
+	var otherPredefined []asserts.Assertion
+	buckets := []string{"root", "generic"}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	defer cancel()
+
+	for _, bucket := range buckets {
+		objectCh := minioClient.ListObjects(ctx, bucket, minio.ListObjectsOptions{
+			Recursive: true,
+		})
+		for object := range objectCh {
+			if strings.Contains(object.Key, "assertion") {
+				logrus.Tracef("Assertion key: %s", object.Key)
+				filename := object.Key
+				logrus.Tracef("Assertion filename: %s", filename)
+
+				objectPtr, err := minioClient.GetObject(ctx, bucket, object.Key, minio.GetObjectOptions{})
+				if err != nil {
+					panic(err)
+				}
+
+				assertionBytes, _ := ioutil.ReadAll(objectPtr)
+				logrus.Trace("assertion:")
+				logrus.Trace(string(assertionBytes))
+				assertion, err := asserts.Decode(assertionBytes)
+				if err != nil {
+					panic(err)
+				} else {
+					logrus.Tracef("assertion type: %s", assertion.Type().Name)
+
+					if assertion.Type() == asserts.AccountKeyType {
+						trusted = append(trusted, assertion)
+					} else if assertion.Type() == asserts.AccountType {
+						trusted = append(trusted, assertion)
+					} else {
+						otherPredefined = append(otherPredefined, assertion)
+					}
+				}
+			}
+		}
+	}
+
+	cfg := asserts.DatabaseConfig{
+		Trusted:         trusted,
+		OtherPredefined: otherPredefined,
+		Backstore:       asserts.NewMemoryBackstore(),
+		KeypairManager:  asserts.NewMemoryKeypairManager(),
+		Checkers:        nil,
+	}
+
+	return &cfg, nil
 }

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -3,11 +3,15 @@ package store
 import "github.com/gin-gonic/gin"
 
 func (s *Store) SetupEndpoints(r *gin.Engine) {
+	r.GET("/api/v1/snaps/assertions/account/:id", s.getAccountAssertion)
+	r.GET("/api/v1/snaps/assertions/account-key/:key", s.getAccountKey)
 	r.GET("/api/v1/snaps/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)
 	r.GET("/api/v1/snaps/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 	r.GET("/api/v1/snaps/names", s.getSnapNames)
 	r.GET("/api/v1/snaps/sections", s.getSnapSections)
 
+	r.GET("/v2/assertions/account/:id", s.getAccountAssertion)
+	r.GET("/v2/assertions/account-key/:key", s.getAccountKey)
 	r.GET("/v2/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)
 	r.GET("/v2/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 	r.GET("/v2/snaps/find", s.findSnap)
@@ -16,12 +20,6 @@ func (s *Store) SetupEndpoints(r *gin.Engine) {
 	r.GET("/download/snaps/:filename", s.snapDownload)
 
 	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
-	r.GET("/api/v1/snaps/assertions/account-key/:key", s.getAccountKey)
-	r.GET("/v2/assertions/account-key/:key", s.getAccountKey)
-
-	r.GET("/api/v1/snaps/assertions/account/:id", s.getAccountAssertion)
-	r.GET("/v2/assertions/account/:id", s.getAccountAssertion)
-
 	r.POST("/unscanned-upload/", s.unscannedUpload)
 
 	// auth: https://api.snapcraft.io/docs/auth.html

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -5,6 +5,9 @@ import "github.com/gin-gonic/gin"
 func (s *Store) SetupEndpoints(r *gin.Engine) {
 	r.GET("/api/v1/snaps/sections", s.getSnapSections)
 	r.GET("/api/v1/snaps/names", s.getSnapNames)
+
+	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
+
 	r.GET("/v2/snaps/find", s.findSnap)
 	r.POST("/v2/snaps/refresh", s.snapRefresh)
 	r.GET("/download/snaps/:filename", s.snapDownload)

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -5,12 +5,13 @@ import "github.com/gin-gonic/gin"
 func (s *Store) SetupEndpoints(r *gin.Engine) {
 	r.GET("/api/v1/snaps/sections", s.getSnapSections)
 	r.GET("/api/v1/snaps/names", s.getSnapNames)
+
 	r.GET("/v2/snaps/find", s.findSnap)
 	r.POST("/v2/snaps/refresh", s.snapRefresh)
 
-	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
-
 	r.GET("/download/snaps/:filename", s.snapDownload)
+
+	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
 
 	r.GET("/api/v1/snaps/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 	r.GET("/v2/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -3,8 +3,9 @@ package store
 import "github.com/gin-gonic/gin"
 
 func (s *Store) SetupEndpoints(r *gin.Engine) {
-	r.GET("/api/v1/snaps/sections", s.getSnapSections)
+	r.GET("/api/v1/snaps/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 	r.GET("/api/v1/snaps/names", s.getSnapNames)
+	r.GET("/api/v1/snaps/sections", s.getSnapSections)
 
 	r.GET("/v2/snaps/find", s.findSnap)
 	r.POST("/v2/snaps/refresh", s.snapRefresh)
@@ -13,7 +14,6 @@ func (s *Store) SetupEndpoints(r *gin.Engine) {
 
 	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
 
-	r.GET("/api/v1/snaps/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 	r.GET("/v2/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 
 	r.GET("/api/v1/snaps/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -6,10 +6,10 @@ func (s *Store) SetupEndpoints(r *gin.Engine) {
 	r.GET("/api/v1/snaps/sections", s.getSnapSections)
 	r.GET("/api/v1/snaps/names", s.getSnapNames)
 	r.GET("/v2/snaps/find", s.findSnap)
+	r.POST("/v2/snaps/refresh", s.snapRefresh)
 
 	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
 
-	r.POST("/v2/snaps/refresh", s.snapRefresh)
 	r.GET("/download/snaps/:filename", s.snapDownload)
 
 	r.GET("/api/v1/snaps/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -5,10 +5,10 @@ import "github.com/gin-gonic/gin"
 func (s *Store) SetupEndpoints(r *gin.Engine) {
 	r.GET("/api/v1/snaps/sections", s.getSnapSections)
 	r.GET("/api/v1/snaps/names", s.getSnapNames)
+	r.GET("/v2/snaps/find", s.findSnap)
 
 	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
 
-	r.GET("/v2/snaps/find", s.findSnap)
 	r.POST("/v2/snaps/refresh", s.snapRefresh)
 	r.GET("/download/snaps/:filename", s.snapDownload)
 

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -3,6 +3,12 @@ package store
 import "github.com/gin-gonic/gin"
 
 func (s *Store) SetupEndpoints(r *gin.Engine) {
+	// auth: https://api.snapcraft.io/docs/auth.html
+	r.POST("/api/v1/snaps/auth/devices", s.authDevicePOST)
+	r.POST("/api/v1/snaps/auth/nonces", s.authNonce)
+	r.POST("/api/v1/snaps/auth/request-id", s.authRequestIdPOST)
+	r.POST("/api/v1/snaps/auth/sessions", s.authSession)
+
 	r.GET("/api/v1/snaps/assertions/account/:id", s.getAccountAssertion)
 	r.GET("/api/v1/snaps/assertions/account-key/:key", s.getAccountKey)
 	r.GET("/api/v1/snaps/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)
@@ -19,12 +25,5 @@ func (s *Store) SetupEndpoints(r *gin.Engine) {
 
 	r.GET("/download/snaps/:filename", s.snapDownload)
 
-	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
 	r.POST("/unscanned-upload/", s.unscannedUpload)
-
-	// auth: https://api.snapcraft.io/docs/auth.html
-	r.POST("/api/v1/snaps/auth/request-id", s.authRequestIdPOST)
-	r.POST("/api/v1/snaps/auth/devices", s.authDevicePOST)
-	r.POST("/api/v1/snaps/auth/nonces", s.authNonce)
-	r.POST("/api/v1/snaps/auth/sessions", s.authSession)
 }

--- a/pkg/store/endpoints.go
+++ b/pkg/store/endpoints.go
@@ -3,22 +3,19 @@ package store
 import "github.com/gin-gonic/gin"
 
 func (s *Store) SetupEndpoints(r *gin.Engine) {
+	r.GET("/api/v1/snaps/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)
 	r.GET("/api/v1/snaps/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 	r.GET("/api/v1/snaps/names", s.getSnapNames)
 	r.GET("/api/v1/snaps/sections", s.getSnapSections)
 
+	r.GET("/v2/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)
+	r.GET("/v2/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
 	r.GET("/v2/snaps/find", s.findSnap)
 	r.POST("/v2/snaps/refresh", s.snapRefresh)
 
 	r.GET("/download/snaps/:filename", s.snapDownload)
 
 	// ----- EVERYTHING BELOW THIS LINE IS FUBAR
-
-	r.GET("/v2/assertions/snap-revision/:sha3384digest", s.getSnapRevisionAssertion)
-
-	r.GET("/api/v1/snaps/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)
-	r.GET("/v2/assertions/snap-declaration/16/:snap-id", s.getSnapDeclarationAssertion)
-
 	r.GET("/api/v1/snaps/assertions/account-key/:key", s.getAccountKey)
 	r.GET("/v2/assertions/account-key/:key", s.getAccountKey)
 

--- a/pkg/store/handler.go
+++ b/pkg/store/handler.go
@@ -3,6 +3,10 @@ package store
 import (
 	"errors"
 
+	"github.com/snapcore/snapd/snap"
+
+	"github.com/sirupsen/logrus"
+
 	"github.com/freetocompute/kebe/pkg/repositories"
 	"github.com/freetocompute/kebe/pkg/store/responses"
 )
@@ -10,6 +14,7 @@ import (
 type IStoreHandler interface {
 	GetSections() (*responses.SectionResults, error)
 	GetSnapNames() (*responses.CatalogResults, error)
+	FindSnap(name string) (*responses.SearchV2Results, error)
 }
 
 type Handler struct {
@@ -22,6 +27,85 @@ func NewHandler(accts repositories.IAccountRepository, snaps repositories.ISnaps
 		accts,
 		snaps,
 	}
+}
+
+func (h *Handler) FindSnap(name string) (*responses.SearchV2Results, error) {
+	//var snapEntry models.SnapEntry
+	//
+	searchResult := responses.SearchV2Results{
+		ErrorList: nil,
+	}
+
+	snapEntry, err := h.snaps.GetSnap(name, true)
+	if err == nil && snapEntry != nil {
+
+		//db := s.db.Preload(clause.Associations).Where(&models.SnapEntry{Name: name}).Find(&snapEntry)
+		//if _, ok := database.CheckDBForErrorOrNoRows(db); ok {
+		results := func() []responses.StoreSearchResult {
+			var results []responses.StoreSearchResult
+
+			snapType := snap.TypeApp
+			switch snapEntry.Type {
+			case "os":
+				snapType = snap.TypeOS
+			case "snapd":
+				snapType = snap.TypeSnapd
+			case "base":
+				snapType = snap.TypeBase
+			case "gadget":
+				snapType = snap.TypeGadget
+			case "kernel":
+				snapType = snap.TypeKernel
+			}
+
+			results = append(results, responses.StoreSearchResult{
+				Revision: responses.StoreSearchChannelSnap{
+					StoreSnap: responses.StoreSnap{
+						Confinement: snapEntry.Confinement,
+						CreatedAt:   snapEntry.CreatedAt.String(),
+						Name:        snapEntry.Name,
+						// TODO: need to fix this properly
+						Revision:  1,
+						SnapID:    snapEntry.SnapStoreID,
+						Type:      snapType,
+						Publisher: snap.StoreAccount{ID: snapEntry.Account.AccountId, Username: snapEntry.Account.Username, DisplayName: snapEntry.Account.DisplayName},
+					},
+				},
+				Snap: responses.StoreSnap{
+					Confinement: snapEntry.Confinement,
+					CreatedAt:   snapEntry.CreatedAt.String(),
+					Name:        snapEntry.Name,
+					// TODO: need to fix this properly
+					Revision:  1,
+					SnapID:    snapEntry.SnapStoreID,
+					Type:      snapType,
+					Publisher: snap.StoreAccount{ID: snapEntry.Account.AccountId, Username: snapEntry.Account.Username, DisplayName: snapEntry.Account.DisplayName},
+				},
+				Name:   snapEntry.Name,
+				SnapID: snapEntry.SnapStoreID,
+			})
+
+			return results
+		}()
+
+		searchResult.Results = results
+		return &searchResult, nil
+		//
+		//logrus.Infof("%+v", searchResult)
+		//
+		//c.Writer.Header().Set("Content-Type", "application/json")
+		//bytes, _ := json.Marshal(&searchResult)
+		//_, err2 := c.Writer.Write(bytes)
+		//if err2 != nil {
+		//	logrus.Error(err2)
+		//	c.AbortWithStatus(http.StatusInternalServerError)
+		//}
+	} else if err != nil {
+		logrus.Error(err)
+		return nil, err
+	}
+
+	return nil, errors.New("unknown error encountered in FindSnap")
 }
 
 func (h *Handler) GetSnapNames() (*responses.CatalogResults, error) {

--- a/pkg/store/handler.go
+++ b/pkg/store/handler.go
@@ -1,0 +1,77 @@
+package store
+
+import (
+	"errors"
+
+	"github.com/freetocompute/kebe/pkg/repositories"
+	"github.com/freetocompute/kebe/pkg/store/responses"
+)
+
+type IStoreHandler interface {
+	GetSections() (*responses.SectionResults, error)
+	GetSnapNames() (*responses.CatalogResults, error)
+}
+
+type Handler struct {
+	accounts repositories.IAccountRepository
+	snaps    repositories.ISnapsRepository
+}
+
+func NewHandler(accts repositories.IAccountRepository, snaps repositories.ISnapsRepository) *Handler {
+	return &Handler{
+		accts,
+		snaps,
+	}
+}
+
+func (h *Handler) GetSnapNames() (*responses.CatalogResults, error) {
+	snaps, err := h.snaps.GetSnaps()
+	if err == nil && snaps != nil {
+		catalogItems := responses.CatalogResults{
+			Payload: responses.CatalogPayload{
+				Items: []responses.CatalogItem{},
+			},
+		}
+
+		for _, sn := range *snaps {
+			catalogItems.Payload.Items = append(catalogItems.Payload.Items, responses.CatalogItem{
+				Name: sn.Name,
+				// TODO: implement version
+				Version: "none provided",
+				// TODO: implement summary
+				Summary: "none provided",
+				// TODO: implement aliases
+				Aliases: nil,
+				// TODO: implement apps
+				Apps: nil,
+				// TODO: implement title
+				Title: "none provided",
+			})
+		}
+
+		return &catalogItems, nil
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return nil, errors.New("unknown error encountered")
+}
+
+func (h *Handler) GetSections() (*responses.SectionResults, error) {
+	sections, err := h.snaps.GetSections()
+	if err == nil && sections != nil {
+		results := responses.SectionResults{
+			Payload: responses.Payload{
+				Sections: []responses.Section{
+					{Name: "general"},
+				},
+			},
+		}
+
+		return &results, nil
+	}
+
+	return nil, errors.New("unknown error")
+}

--- a/pkg/store/requests/requests.go
+++ b/pkg/store/requests/requests.go
@@ -1,13 +1,10 @@
 package requests
 
 import (
-	"github.com/snapcore/snapd/snap"
 	"time"
-)
 
-type RequestIDResp struct {
-	RequestID string `json:"request-id"`
-}
+	"github.com/snapcore/snapd/snap"
+)
 
 type SnapActionRequest struct {
 	Context             []*CurrentSnapV2JSON `json:"context"`

--- a/pkg/store/responses/responses.go
+++ b/pkg/store/responses/responses.go
@@ -147,3 +147,7 @@ type Nonce struct {
 type Session struct {
 	Macaroon string `json:"macaroon"`
 }
+
+type AuthRequestIDResp struct {
+	RequestID string `json:"request-id"`
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -92,13 +92,20 @@ func GetDatabaseWithRootKey() *asserts.Database {
 
 func (s *Store) snapDownload(c *gin.Context) {
 	snapFilename := c.Param("filename")
-	obs := objectstore.NewObjectStore()
-	bytes, _ := obs.GetFileFromBucket("snaps", snapFilename)
-	_, err := c.Writer.Write(*bytes)
-	if err != nil {
-		logrus.Error(err)
-		c.AbortWithStatus(http.StatusInternalServerError)
+
+	bytes, err := s.handler.SnapDownload(snapFilename)
+	if err == nil && bytes != nil {
+		_, err2 := c.Writer.Write(*bytes)
+		if err2 != nil {
+			logrus.Error(err2)
+			c.AbortWithStatus(http.StatusInternalServerError)
+			return
+		}
+
+		return
 	}
+
+	c.AbortWithStatus(http.StatusInternalServerError)
 }
 
 func (s *Store) snapRefresh(c *gin.Context) {


### PR DESCRIPTION
This is the first major refactor of the code base since establishing some basic functionality that allows for self-hosting a store, registering snaps, uploading, installing, etc.

This takes out the direct dependency of the database object (and some other things) to the services that run for the REST API.

This should make it easier to add unit tests and add new functionality without breaking existing functionality.